### PR TITLE
dispose subscription handler on HttpServer disposing

### DIFF
--- a/Anna/HttpServer.cs
+++ b/Anna/HttpServer.cs
@@ -16,6 +16,7 @@ namespace Anna
     {
         private readonly HttpListener listener;
         private readonly IObservable<RequestContext> stream;
+        private IDisposable subscription;
 
         //URI - METHOD
         private readonly List<Tuple<string, string>> handledRoutes 
@@ -45,7 +46,7 @@ namespace Anna
                 .Repeat().Retry()
                 .Publish().RefCount().ObserveOn(scheduler);
 
-            observableHttpContext.Subscribe(new UnhandledRouteObserver(handledRoutes));
+            subscription = observableHttpContext.Subscribe(new UnhandledRouteObserver(handledRoutes));
             return observableHttpContext;
         }
 
@@ -53,6 +54,7 @@ namespace Anna
         public void Dispose()
         {
             listener.Stop();
+            subscription.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
Problem: a subscrition handler is not disposed on HttpServer object destroying. As result it leads to hang threads and process. Looks like it's work-related Rx Observable collections.
This problem was found with test:
```C#
[Test]
public void TestDisposing()
{
    for (var i = 0; i< 10000; i++)
        using (var server = new HttpServer("http://*:1234/"))
        {
        }
}
```
This test hangs before the fix and works fine after