### PR TITLE
PR: Be able to set other Content-Type rather than "text/html"

### DIFF
--- a/Anna/Responses/Response.cs
+++ b/Anna/Responses/Response.cs
@@ -22,7 +22,7 @@ namespace Anna.Responses
             Headers = new Dictionary<string, string> { { "Content-Type", "text/html" } };
             if (headers != null)
                 foreach (var pair in headers)
-                    Headers.Add(pair);
+                    Headers[pair.Key] = pair.Value;
 
             listenerResponse = context.ListenerResponse;
         }


### PR DESCRIPTION
Content-Type is always set by default to "text/html" in the constructor of Response class.
If you want to create a response with a image or something different and you provide the new Content-Type in the headers dictionary passed in the constructor an exception is thrown when it tries to add the new "Content-Type" because the Add method was used. This method checks if the same key is present and throws.

One workaround that I used, was to create the response and manually overwrite because the Headers member is public but this approach forces you not to write inline clean code.

This is definitely a bug and in order to solve it the Add method was replaced with []. In this case the content type can be overwritten and also other headers can be added.